### PR TITLE
Fix clipboard paste handling

### DIFF
--- a/app/src/main/java/com/alisher/aside/AsideScreen.kt
+++ b/app/src/main/java/com/alisher/aside/AsideScreen.kt
@@ -49,7 +49,11 @@ fun AsideScreen() {
                 .clickable {
                     val clipboard = context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
                     val clip = clipboard.primaryClip
-                    val pasted = clip?.getItemAt(0)?.text?.toString() ?: "Clipboard is empty"
+                    val pasted = if (clip != null && clip.itemCount > 0) {
+                        clip.getItemAt(0).text?.toString()
+                    } else {
+                        "Clipboard is empty"
+                    }
                     Toast.makeText(context, "Pasted: $pasted", Toast.LENGTH_SHORT).show()
                 },
             contentAlignment = Alignment.Center // ✅ center it properly


### PR DESCRIPTION
## Summary
- handle empty clipboard case safely in `AsideScreen`

## Testing
- `./gradlew test` *(fails: Downloading https://services.gradle.org/distributions/gradle-8.11.1-bin.zip failed: timeout)*