### PR TITLE
Introduce typography tokens

### DIFF
--- a/app/src/main/res/values/typescale.xml
+++ b/app/src/main/res/values/typescale.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <dimen name="font_display_md">24sp</dimen>
-    <dimen name="font_body_md">16sp</dimen>
+    <dimen name="font_headline">24sp</dimen>
+    <dimen name="font_body">16sp</dimen>
+    <dimen name="font_messages">16sp</dimen>
+    <dimen name="line_height_messages">24sp</dimen>
+    <dimen name="font_tag">12sp</dimen>
 </resources>

--- a/ui/theme/AsideTheme.kt
+++ b/ui/theme/AsideTheme.kt
@@ -1,0 +1,61 @@
+package com.alisher.aside.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Typography
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Color
+
+private val AsideColorScheme = darkColorScheme(
+    background = BlackHole,
+    surface = GrayGraphene,
+    primary = PurplePrivate,
+    secondary = YellowCone,
+    tertiary = RedAlarm,
+    onPrimary = WhitePure,
+    onSecondary = BlackHole,
+    onTertiary = WhitePure,
+    onBackground = WhitePure,
+    onSurface = WhitePure
+)
+
+data class AsideColors(
+    val blackHole: Color = BlackHole,
+    val grayCharcoal: Color = GrayCharcoal,
+    val grayGraphene: Color = GrayGraphene,
+    val grayShadow: Color = GrayShadow,
+    val grayDust: Color = GrayDust,
+    val whitePure: Color = WhitePure,
+    val yellowCone: Color = YellowCone,
+    val mustardPulse: Color = MustardPulse,
+    val purplePrivate: Color = PurplePrivate,
+    val redAlarm: Color = RedAlarm
+)
+
+private val LocalAsideColors = staticCompositionLocalOf { AsideColors() }
+
+object AsideTheme {
+    val colors: AsideColors
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalAsideColors.current
+
+    val typography: Typography
+        @Composable
+        @ReadOnlyComposable
+        get() = AsideTypography
+}
+
+@Composable
+fun AsideTheme(content: @Composable () -> Unit) {
+    CompositionLocalProvider(LocalAsideColors provides AsideColors()) {
+        MaterialTheme(
+            colorScheme = AsideColorScheme,
+            typography = AsideTypography,
+            content = content
+        )
+    }
+}

--- a/ui/theme/AsideTypography.kt
+++ b/ui/theme/AsideTypography.kt
@@ -1,0 +1,10 @@
+package com.alisher.aside.ui.theme
+
+import androidx.compose.material3.Typography
+
+val AsideTypography = Typography(
+    headlineMedium = Headline,
+    bodyMedium = Body,
+    bodyLarge = Messages,
+    labelSmall = Tag
+)

--- a/ui/theme/TypeTokens.kt
+++ b/ui/theme/TypeTokens.kt
@@ -1,0 +1,10 @@
+package com.alisher.aside.ui.theme
+
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+val Headline = TextStyle(fontSize = 24.sp, fontWeight = FontWeight.Bold)
+val Body     = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Normal)
+val Messages = TextStyle(fontSize = 16.sp, fontWeight = FontWeight.Normal, lineHeight = 24.sp)
+val Tag      = TextStyle(fontSize = 12.sp, fontWeight = FontWeight.Normal)


### PR DESCRIPTION
## Summary
- add typography token definitions
- create `AsideTypography` with roles mapped to tokens
- inject typography tokens into `AsideTheme`
- expose token values through `typescale.xml`

## Testing
- `pre-commit` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*