### PR TITLE
Add ExitButton component

### DIFF
--- a/app/src/main/java/com/alisher/aside/ui/components/ExitButton.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/ExitButton.kt
@@ -1,0 +1,29 @@
+package com.alisher.aside.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.sizeIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.material3.Text
+import com.alisher.aside.ui.theme.AsideTheme
+
+@Composable
+fun ExitButton(onClick: () -> Unit) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .sizeIn(minWidth = 48.dp, minHeight = 48.dp)
+            .clickable { onClick() }
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        Text(
+            text = "Exit",
+            style = AsideTheme.typography.bodyLarge,
+            color = AsideTheme.colors.whitePure
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ExitButton` composable using `AsideTheme.typography.bodyLarge`
- ensure touch target >=48dp via `Modifier.sizeIn`

## Testing
- `gradlew test` *(fails: No route to host while downloading Gradle)*

------
https://chatgpt.com/codex/tasks/task_b_683bc92b8f048331a10d59ded495ab6f