### PR TITLE
Add ExitButtonPreview for visual testing

### DIFF
--- a/app/src/main/java/com/alisher/aside/ui/debug/ExitButtonPreview.kt
+++ b/app/src/main/java/com/alisher/aside/ui/debug/ExitButtonPreview.kt
@@ -1,0 +1,18 @@
+package com.alisher.aside.ui.debug
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.alisher.aside.ui.components.ExitButton
+import com.alisher.aside.ui.theme.AsideTheme
+
+@Preview(
+    showBackground = true,
+    backgroundColor = 0xFF202020
+)
+@Composable
+fun ExitButtonPreview() {
+    AsideTheme {
+        ExitButton {}
+    }
+}
+


### PR DESCRIPTION
## Summary
- add an `ExitButtonPreview` composable for design-time checks

## Testing
- `gradlew test` *(skipped: no build instructions)*

------
https://chatgpt.com/codex/tasks/task_b_683bcf99cbc08331980b4cf79095a4e4