### PR TITLE
Add SessionTopBar component with preview

### DIFF
--- a/app/src/main/java/com/alisher/aside/ui/components/SessionTopBar.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/SessionTopBar.kt
@@ -1,0 +1,29 @@
+package com.alisher.aside.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.alisher.aside.ui.theme.AsideTheme
+
+@Composable
+fun SessionTopBar(
+    peerState: PeerState,
+    onExit: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .background(AsideTheme.colors.blackHole)
+            .padding(horizontal = 20.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        ConnectionStatus(peerState)
+        Spacer(modifier = Modifier.weight(1f))
+        ExitButton(onExit)
+    }
+}

--- a/app/src/main/java/com/alisher/aside/ui/debug/SessionTopBarPreview.kt
+++ b/app/src/main/java/com/alisher/aside/ui/debug/SessionTopBarPreview.kt
@@ -1,0 +1,15 @@
+package com.alisher.aside.ui.debug
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.alisher.aside.ui.components.SessionTopBar
+import com.alisher.aside.ui.components.PeerState
+import com.alisher.aside.ui.theme.AsideTheme
+
+@Preview(showBackground = true, backgroundColor = 0xFF202020)
+@Composable
+fun SessionTopBarPreview() {
+    AsideTheme {
+        SessionTopBar(peerState = PeerState.Offline) {}
+    }
+}


### PR DESCRIPTION
## Summary
- add `SessionTopBar` composable to show connection status and exit action
- create a preview to visualize the top bar in Android Studio

## Testing
- `gradle` build skipped as requested

------
https://chatgpt.com/codex/tasks/task_b_683bd2a0a01c8331afaa7c9bdee991b9