### PR TITLE
Add MessageStatusIndicator component

### DIFF
--- a/app/src/main/java/com/alisher/aside/ui/components/MessageStatusIndicator.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/MessageStatusIndicator.kt
@@ -1,0 +1,52 @@
+package com.alisher.aside.ui.components
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.alisher.aside.ui.theme.AsideTheme
+
+enum class MessageStatus {
+    Queued,
+    Sent,
+    Delivered,
+    Failed
+}
+
+@Composable
+fun MessageStatusIndicator(
+    status: MessageStatus,
+    modifier: Modifier = Modifier
+) {
+    // Choose the Unicode icon character and color from the theme:
+    val (icon, color) = when (status) {
+        MessageStatus.Queued    -> "⧗"  to AsideTheme.colors.grayDust
+        MessageStatus.Sent      -> "✓"   to AsideTheme.colors.whitePure
+        MessageStatus.Delivered -> "✓✓"  to AsideTheme.colors.purplePrivate
+        MessageStatus.Failed    -> "⟳"   to AsideTheme.colors.redAlarm
+    }
+
+    Row(modifier = modifier) {
+        // Icon text (tag style, appropriate color)
+        Text(
+            text  = icon,
+            style = AsideTheme.typography.labelSmall,
+            color = color
+        )
+        Spacer(Modifier.width(8.dp))
+        // Status label text
+        Text(
+            text  = when (status) {
+                MessageStatus.Queued    -> "Queued to send"
+                MessageStatus.Sent      -> "Sent"
+                MessageStatus.Delivered -> "Delivered"
+                MessageStatus.Failed    -> "Failed to send"
+            },
+            style = AsideTheme.typography.labelSmall,
+            color = color
+        )
+    }
+}

--- a/app/src/main/java/com/alisher/aside/ui/debug/MessageStatusPreview.kt
+++ b/app/src/main/java/com/alisher/aside/ui/debug/MessageStatusPreview.kt
@@ -1,0 +1,40 @@
+package com.alisher.aside.ui.debug
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.alisher.aside.ui.components.MessageStatus
+import com.alisher.aside.ui.components.MessageStatusIndicator
+import com.alisher.aside.ui.theme.AsideTheme
+
+@Preview(showBackground = false)
+@Composable
+fun MessageStatusPreview() {
+    AsideTheme {
+        Column(
+            Modifier
+                .fillMaxSize()
+                .background(AsideTheme.colors.blackHole)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+            horizontalAlignment = Alignment.Start
+        ) {
+            MessageStatusIndicator(status = MessageStatus.Queued)
+            Spacer(Modifier.height(8.dp))
+            MessageStatusIndicator(status = MessageStatus.Sent)
+            Spacer(Modifier.height(8.dp))
+            MessageStatusIndicator(status = MessageStatus.Delivered)
+            Spacer(Modifier.height(8.dp))
+            MessageStatusIndicator(status = MessageStatus.Failed)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add MessageStatusIndicator composable for message state display
- add design-time preview for all message status states
- fix status indicator text style to use tag typography

## Testing
- `gradlew test` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683be16247048331b262f0b5d608e9b3