### PR TITLE
Add ChatScreen composable

### DIFF
--- a/app/src/main/java/com/alisher/aside/ui/components/ChatScreen.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/ChatScreen.kt
@@ -1,26 +1,88 @@
-ackage com.alisher.aside.ui
+package com.alisher.aside.ui.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.viewmodel.compose.viewModel
-import com.alisher.aside.ui.components.SessionTopBar
-import com.alisher.aside.ui.session.SessionViewModel
+import androidx.compose.ui.unit.dp
+import com.alisher.aside.ui.theme.AsideTheme
 
+/** Data class representing a chat message. */
+data class ChatMessage(
+    val type: MessageType,
+    val text: String,
+    val status: MessageStatus? = null
+)
+
+/**
+ * Full chat screen with a list of messages, input field and send/queue button.
+ *
+ * @param messages       Conversation history to display.
+ * @param peerState      Current peer connection state for the top bar.
+ * @param onSendMessage  Called when user submits a message.
+ * @param onExit         Called when exit action is tapped.
+ */
 @Composable
 fun ChatScreen(
-    viewModel: SessionViewModel = viewModel(),
-    onExit: () -> Unit
+    messages: List<ChatMessage>,
+    peerState: PeerState,
+    onSendMessage: (String) -> Unit,
+    onExit: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
-    Column(Modifier.fillMaxSize()) {
+    var input by remember { mutableStateOf("") }
 
-        // top bar
-        SessionTopBar(
-            peerState = viewModel.peerState.collectAsState().value,
-            onExit    = onExit
-        )
+    Column(modifier.fillMaxSize()) {
+        SessionTopBar(peerState = peerState, onExit = onExit)
 
-        // TODO: message list + input go here
+        LazyColumn(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .background(AsideTheme.colors.blackHole)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(messages) { msg ->
+                Message(
+                    type = msg.type,
+                    text = msg.text,
+                    messageStatusState = msg.status
+                )
+            }
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(AsideTheme.colors.blackHole)
+                .padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
+            verticalAlignment = Alignment.Bottom
+        ) {
+            InputField(
+                text = input,
+                onValueChange = { input = it },
+                modifier = Modifier.weight(1f)
+            )
+
+            Spacer(Modifier.width(16.dp))
+
+            val buttonState = if (input.isEmpty()) ButtonState.Disabled else ButtonState.Default
+            val buttonType = if (peerState == PeerState.Connected) ButtonType.Send else ButtonType.Queue
+            SendQueueButton(
+                type = buttonType,
+                state = buttonState,
+                onClick = {
+                    if (input.isNotBlank()) {
+                        onSendMessage(input)
+                        input = ""
+                    }
+                },
+                modifier = Modifier.align(Alignment.Bottom)
+            )
+        }
     }
 }

--- a/app/src/main/java/com/alisher/aside/ui/debug/ChatScreenPreview.kt
+++ b/app/src/main/java/com/alisher/aside/ui/debug/ChatScreenPreview.kt
@@ -1,0 +1,56 @@
+package com.alisher.aside.ui.debug
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.alisher.aside.ui.components.*
+import com.alisher.aside.ui.theme.AsideTheme
+
+@Preview(showBackground = true, backgroundColor = 0xFF202020)
+@Composable
+fun ChatScreenPreview() {
+    AsideTheme {
+        val messages = remember {
+            mutableStateListOf(
+                ChatMessage(MessageType.In, "Hey, you there?"),
+                ChatMessage(MessageType.Out, "Always", MessageStatus.Delivered),
+                ChatMessage(MessageType.In, "Good to know")
+            )
+        }
+        val online = remember { mutableStateOf(true) }
+
+        Column(Modifier.fillMaxSize()) {
+            ChatScreen(
+                messages = messages,
+                peerState = if (online.value) PeerState.Connected else PeerState.Offline,
+                onSendMessage = { text ->
+                    val status = if (online.value) MessageStatus.Sent else MessageStatus.Queued
+                    messages.add(ChatMessage(MessageType.Out, text, status))
+                },
+                onExit = { messages.clear() }
+            )
+
+            Row(Modifier.padding(16.dp), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                SendQueueButton(
+                    type = ButtonType.Send,
+                    state = ButtonState.Default,
+                    onClick = { online.value = true }
+                )
+                SendQueueButton(
+                    type = ButtonType.Queue,
+                    state = ButtonState.Default,
+                    onClick = { online.value = false }
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- build the ChatScreen composable with message list and input
- show off ChatScreen in a preview

## Testing
- `./gradlew build -x test` *(fails: No route to host)*

------
https://chatgpt.com/codex/tasks/task_b_683c5606745083318b38e3e90604ff53