### PR TITLE
Simplify ChatScreen

### DIFF
--- a/app/src/main/java/com/alisher/aside/ui/components/ChatScreen.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/ChatScreen.kt
@@ -1,88 +1,51 @@
 package com.alisher.aside.ui.components
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
-import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.weight
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.alisher.aside.ui.theme.AsideTheme
-
-/** Data class representing a chat message. */
-data class ChatMessage(
-    val type: MessageType,
-    val text: String,
-    val status: MessageStatus? = null
-)
+import com.alisher.aside.ui.components.InputField
+import com.alisher.aside.ui.components.SessionTopBar
+import com.alisher.aside.ui.components.PeerState
 
 /**
- * Full chat screen with a list of messages, input field and send/queue button.
+ * Minimal chat screen used during early development.
+ * It shows the session top bar and an input field at the bottom.
+ * Message list and send logic will be added later.
  *
- * @param messages       Conversation history to display.
- * @param peerState      Current peer connection state for the top bar.
- * @param onSendMessage  Called when user submits a message.
- * @param onExit         Called when exit action is tapped.
+ * @param peerState Current peer connection state for the top bar.
+ * @param onExit    Called when exit action is tapped.
  */
 @Composable
 fun ChatScreen(
-    messages: List<ChatMessage>,
     peerState: PeerState,
-    onSendMessage: (String) -> Unit,
     onExit: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var input by remember { mutableStateOf("") }
 
-    Column(modifier.fillMaxSize()) {
+    Column(modifier.fillMaxSize().background(AsideTheme.colors.blackHole)) {
         SessionTopBar(peerState = peerState, onExit = onExit)
 
-        LazyColumn(
-            modifier = Modifier
-                .weight(1f)
-                .fillMaxWidth()
-                .background(AsideTheme.colors.blackHole)
-                .padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            items(messages) { msg ->
-                Message(
-                    type = msg.type,
-                    text = msg.text,
-                    messageStatusState = msg.status
-                )
-            }
-        }
+        Spacer(modifier = Modifier.weight(1f))
 
-        Row(
+        InputField(
+            text = input,
+            onValueChange = { input = it },
             modifier = Modifier
                 .fillMaxWidth()
-                .background(AsideTheme.colors.blackHole)
-                .padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
-            verticalAlignment = Alignment.Bottom
-        ) {
-            InputField(
-                text = input,
-                onValueChange = { input = it },
-                modifier = Modifier.weight(1f)
-            )
-
-            Spacer(Modifier.width(16.dp))
-
-            val buttonState = if (input.isEmpty()) ButtonState.Disabled else ButtonState.Default
-            val buttonType = if (peerState == PeerState.Connected) ButtonType.Send else ButtonType.Queue
-            SendQueueButton(
-                type = buttonType,
-                state = buttonState,
-                onClick = {
-                    if (input.isNotBlank()) {
-                        onSendMessage(input)
-                        input = ""
-                    }
-                },
-                modifier = Modifier.align(Alignment.Bottom)
-            )
-        }
+                .padding(start = 16.dp, end = 16.dp, bottom = 8.dp)
+        )
     }
 }

--- a/app/src/main/java/com/alisher/aside/ui/debug/ChatScreenPreview.kt
+++ b/app/src/main/java/com/alisher/aside/ui/debug/ChatScreenPreview.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -19,24 +18,12 @@ import com.alisher.aside.ui.theme.AsideTheme
 @Composable
 fun ChatScreenPreview() {
     AsideTheme {
-        val messages = remember {
-            mutableStateListOf(
-                ChatMessage(MessageType.In, "Hey, you there?"),
-                ChatMessage(MessageType.Out, "Always", MessageStatus.Delivered),
-                ChatMessage(MessageType.In, "Good to know")
-            )
-        }
         val online = remember { mutableStateOf(true) }
 
         Column(Modifier.fillMaxSize()) {
             ChatScreen(
-                messages = messages,
                 peerState = if (online.value) PeerState.Connected else PeerState.Offline,
-                onSendMessage = { text ->
-                    val status = if (online.value) MessageStatus.Sent else MessageStatus.Queued
-                    messages.add(ChatMessage(MessageType.Out, text, status))
-                },
-                onExit = { messages.clear() }
+                onExit = { }
             )
 
             Row(Modifier.padding(16.dp), horizontalArrangement = Arrangement.spacedBy(12.dp)) {


### PR DESCRIPTION
## Summary
- drop message logic from `ChatScreen`
- use `SessionTopBar` and `InputField` only
- update preview accordingly

## Testing
- `./gradlew test --stacktrace` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6843beca84888331a97ec5efd87a745b