### PR TITLE
Implement offline chat creation flow

### DIFF
--- a/app/src/androidTest/java/com/alisher/aside/AsideScreenTest.kt
+++ b/app/src/androidTest/java/com/alisher/aside/AsideScreenTest.kt
@@ -14,7 +14,7 @@ class AsideScreenTest {
     fun mainButtonsAreDisplayed() {
         composeTestRule.setContent {
             AsideTheme {
-                AsideScreen()
+                AsideScreen(onCreate = {})
             }
         }
 

--- a/app/src/main/java/com/alisher/aside/App.kt
+++ b/app/src/main/java/com/alisher/aside/App.kt
@@ -1,0 +1,34 @@
+package com.alisher.aside
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context.CLIPBOARD_SERVICE
+import android.widget.Toast
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import com.alisher.aside.ui.components.ChatScreen
+import com.alisher.aside.ui.components.PeerState
+
+private const val DUMMY_INVITE = "Let\u2019s step aside: 03b1a3cf0ae3f8b6cc1937124e36f51b9e8e3f024f18ec1479d07ec0f27c50a3d9"
+
+enum class AppScreen { Home, Chat }
+
+@Composable
+fun AsideApp() {
+    val context = LocalContext.current
+    val current = remember { mutableStateOf(AppScreen.Home) }
+
+    when (current.value) {
+        AppScreen.Home -> AsideScreen(onCreate = {
+            val clipboard = context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+            clipboard.setPrimaryClip(ClipData.newPlainText("invite", DUMMY_INVITE))
+            Toast.makeText(context, "Invite copied to clipboard. Send it to your peer.", Toast.LENGTH_SHORT).show()
+            current.value = AppScreen.Chat
+        })
+        AppScreen.Chat -> ChatScreen(peerState = PeerState.Offline, onExit = {
+            current.value = AppScreen.Home
+        })
+    }
+}

--- a/app/src/main/java/com/alisher/aside/AsideScreen.kt
+++ b/app/src/main/java/com/alisher/aside/AsideScreen.kt
@@ -20,7 +20,9 @@ import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.systemBars
 
 @Composable
-fun AsideScreen() {
+fun AsideScreen(
+    onCreate: () -> Unit,
+) {
     val context = LocalContext.current
 
     Column(
@@ -72,9 +74,7 @@ fun AsideScreen() {
                 .height(56.dp)
                 .clip(RoundedCornerShape(4.dp))
                 .background(AsideTheme.colors.grayGraphene)
-                .clickable {
-                    Toast.makeText(context, "Create tapped", Toast.LENGTH_SHORT).show()
-                },
+                .clickable { onCreate() },
             contentAlignment = Alignment.Center
         ) {
             Text(

--- a/app/src/main/java/com/alisher/aside/MainActivity.kt
+++ b/app/src/main/java/com/alisher/aside/MainActivity.kt
@@ -3,7 +3,6 @@ package com.alisher.aside
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import com.alisher.aside.ui.debug.SessionTestScreen
 import com.alisher.aside.ui.theme.*
 
 class MainActivity : ComponentActivity() {
@@ -11,7 +10,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             AsideTheme {
-                SessionTestScreen()
+                AsideApp()
             }
         }
     }

--- a/app/src/main/java/com/alisher/aside/ui/components/ChatScreen.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/ChatScreen.kt
@@ -29,9 +29,16 @@ fun ChatScreen(
             // TODO: Replace with LazyColumn for chat messages
         }
 
+        val buttonType = if (peerState == PeerState.Connected) {
+            ButtonType.Send
+        } else {
+            ButtonType.Queue
+        }
+
         InputField(
             text = input,
             onValueChange = { input = it },
+            buttonType = buttonType,
             modifier = Modifier
                 .fillMaxWidth()
                 .windowInsetsPadding(WindowInsets.navigationBars)

--- a/app/src/main/java/com/alisher/aside/ui/components/InputField.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/InputField.kt
@@ -23,6 +23,7 @@ import com.alisher.aside.ui.theme.AsideTheme
 fun InputField(
     text: String,
     onValueChange: (String) -> Unit,
+    buttonType: ButtonType = ButtonType.Send,
     modifier: Modifier = Modifier
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -73,7 +74,7 @@ fun InputField(
 
         val buttonState = if (internalValue.text.isEmpty()) ButtonState.Disabled else ButtonState.Default
         SendQueueButton(
-            type = ButtonType.Send,
+            type = buttonType,
             state = buttonState,
             onClick = {
                 keyboardController?.hide()


### PR DESCRIPTION
## Summary
- add `AsideApp` composable with simple navigation
- allow input field button type selection
- wire chat screen button type to connection state
- expose create handler on home screen
- start `AsideApp` from `MainActivity`

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6843d062282c83318d8cfb11f96595ef