### PR TITLE
Fix input visibility over keyboard

### DIFF
--- a/app/src/main/java/com/alisher/aside/ui/components/ChatScreen.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/ChatScreen.kt
@@ -5,9 +5,6 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.windowInsetsPadding
-import androidx.compose.foundation.layout.navigationBars
 import com.alisher.aside.ui.theme.AsideTheme
 
 @Composable
@@ -39,9 +36,7 @@ fun ChatScreen(
             text = input,
             onValueChange = { input = it },
             buttonType = buttonType,
-            modifier = Modifier
-                .fillMaxWidth()
-                .windowInsetsPadding(WindowInsets.navigationBars)
+            modifier = Modifier.fillMaxWidth()
         )
     }
 }

--- a/app/src/main/java/com/alisher/aside/ui/components/InputField.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/InputField.kt
@@ -2,6 +2,7 @@ package com.alisher.aside.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.navigationBarsWithImePadding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -39,7 +40,8 @@ fun InputField(
         modifier = modifier
             .background(AsideTheme.colors.blackHole)
             .padding(horizontal = 16.dp)
-            .heightIn(min = 48.dp),
+            .heightIn(min = 48.dp)
+            .navigationBarsWithImePadding(),
         verticalAlignment = Alignment.Bottom
     ) {
         var internalValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {


### PR DESCRIPTION
## Summary
- ensure input row follows keyboard and system bars using `navigationBarsWithImePadding`
- simplify ChatScreen bottom padding

## Testing
- `gradle lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6844549423148331b5a2321bac385c93