### PR TITLE
Fix keyboard insets for chat

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,13 +16,14 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.Aside">
+            android:theme="@style/Theme.Aside"
+            android:windowSoftInputMode="adjustNothing">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/alisher/aside/App.kt
+++ b/app/src/main/java/com/alisher/aside/App.kt
@@ -4,31 +4,44 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context.CLIPBOARD_SERVICE
 import android.widget.Toast
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalContext
-import com.alisher.aside.ui.components.ChatScreen
-import com.alisher.aside.ui.components.PeerState
+import com.alisher.aside.ui.components.*
 
-private const val DUMMY_INVITE = "Let\u2019s step aside: 03b1a3cf0ae3f8b6cc1937124e36f51b9e8e3f024f18ec1479d07ec0f27c50a3d9"
+private const val DUMMY_INVITE =
+    "Let\u2019s step aside: 03b1a3cf0ae3f8b6cc1937124e36f51b9e8e3f024f18ec1479d07ec0f27c50a3d9"
 
 enum class AppScreen { Home, Chat }
 
 @Composable
 fun AsideApp() {
-    val context = LocalContext.current
-    val current = remember { mutableStateOf(AppScreen.Home) }
+    val context      = LocalContext.current
+    var screen       by remember { mutableStateOf(AppScreen.Home) }
+    var draft        by rememberSaveable { mutableStateOf("") }
+    val peerState    = remember { PeerState.Offline }   // stub until real connect
 
-    when (current.value) {
-        AppScreen.Home -> AsideScreen(onCreate = {
-            val clipboard = context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
-            clipboard.setPrimaryClip(ClipData.newPlainText("invite", DUMMY_INVITE))
-            Toast.makeText(context, "Invite copied to clipboard. Send it to your peer.", Toast.LENGTH_SHORT).show()
-            current.value = AppScreen.Chat
-        })
-        AppScreen.Chat -> ChatScreen(peerState = PeerState.Offline, onExit = {
-            current.value = AppScreen.Home
-        })
+    when (screen) {
+        AppScreen.Home -> AsideScreen(
+            onCreate = {
+                (context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager)
+                    .setPrimaryClip(ClipData.newPlainText("invite", DUMMY_INVITE))
+                Toast
+                    .makeText(
+                        context,
+                        "Invite copied to clipboard. Send it to your peer.",
+                        Toast.LENGTH_SHORT
+                    )
+                    .show()
+                screen = AppScreen.Chat
+            }
+        )
+
+        AppScreen.Chat -> ChatScreen(
+            peerState     = peerState,
+            draft         = draft,
+            onDraftChange = { draft = it },
+            onExit        = { screen = AppScreen.Home }
+        )
     }
 }

--- a/app/src/main/java/com/alisher/aside/ui/components/ChatScreen.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/ChatScreen.kt
@@ -1,42 +1,32 @@
-    package com.alisher.aside.ui.components
+package com.alisher.aside.ui.components
 
-    import androidx.compose.foundation.background
-    import androidx.compose.foundation.layout.*
-    import androidx.compose.runtime.*
-    import androidx.compose.ui.Modifier
-    import com.alisher.aside.ui.layout.LayoutWrapper
-    import com.alisher.aside.ui.theme.AsideTheme
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.ime
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 
-    @Composable
-    fun ChatScreen(
-        peerState: PeerState,
-        onExit: () -> Unit,
-        modifier: Modifier = Modifier
-    ) {
-        var input by remember { mutableStateOf("") }
-
-        LayoutWrapper(modifier = modifier.background(AsideTheme.colors.blackHole)) {
-            Column(
-                modifier = Modifier.fillMaxSize()
-            ) {
-                SessionTopBar(peerState = peerState, onExit = onExit)
-
-                Box(modifier = Modifier.weight(1f)) {
-                    // TODO: Replace with LazyColumn for chat messages
-                }
-
-            val buttonType = if (peerState == PeerState.Connected) {
-                ButtonType.Send
-            } else {
-                ButtonType.Queue
-            }
-
-                InputField(
-                    text = input,
-                    onValueChange = { input = it },
-                    buttonType = buttonType,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
+@Composable
+fun ChatScreen(
+    peerState: PeerState,
+    draft: String,
+    onDraftChange: (String) -> Unit,
+    onExit: () -> Unit
+) {
+    Scaffold(
+        topBar = { SessionTopBar(peerState, onExit) },
+        bottomBar = {
+            InputField(
+                text          = draft,
+                onValueChange = onDraftChange,
+                modifier      = Modifier
+                    // clears navigation-bar height (3-button mode)
+                    .windowInsetsPadding(WindowInsets.navigationBars)
+                    // clears keyboard + suggestion strip
+                    .windowInsetsPadding(WindowInsets.ime)
+            )
         }
-    }
+    ) { /* messages go here later */ }
+}

--- a/app/src/main/java/com/alisher/aside/ui/components/ChatScreen.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/ChatScreen.kt
@@ -4,10 +4,7 @@
     import androidx.compose.foundation.layout.*
     import androidx.compose.runtime.*
     import androidx.compose.ui.Modifier
-    import androidx.compose.ui.unit.dp
-    import androidx.compose.foundation.layout.WindowInsets
-    import androidx.compose.foundation.layout.windowInsetsPadding
-    import androidx.compose.foundation.layout.navigationBars
+    import com.alisher.aside.ui.layout.LayoutWrapper
     import com.alisher.aside.ui.theme.AsideTheme
 
     @Composable
@@ -18,16 +15,15 @@
     ) {
         var input by remember { mutableStateOf("") }
 
-        Column(
-            modifier = modifier
-                .fillMaxSize()
-                .background(AsideTheme.colors.blackHole)
-        ) {
-            SessionTopBar(peerState = peerState, onExit = onExit)
+        LayoutWrapper(modifier = modifier.background(AsideTheme.colors.blackHole)) {
+            Column(
+                modifier = Modifier.fillMaxSize()
+            ) {
+                SessionTopBar(peerState = peerState, onExit = onExit)
 
-            Box(modifier = Modifier.weight(1f)) {
-                // TODO: Replace with LazyColumn for chat messages
-            }
+                Box(modifier = Modifier.weight(1f)) {
+                    // TODO: Replace with LazyColumn for chat messages
+                }
 
             val buttonType = if (peerState == PeerState.Connected) {
                 ButtonType.Send
@@ -35,13 +31,12 @@
                 ButtonType.Queue
             }
 
-            InputField(
-                text = input,
-                onValueChange = { input = it },
-                buttonType = buttonType,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .windowInsetsPadding(WindowInsets.navigationBars)
-            )
+                InputField(
+                    text = input,
+                    onValueChange = { input = it },
+                    buttonType = buttonType,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
         }
     }

--- a/app/src/main/java/com/alisher/aside/ui/components/InputField.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/InputField.kt
@@ -17,9 +17,8 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.ime
-import androidx.compose.foundation.layout.asPaddingValues
 import com.alisher.aside.ui.theme.AsideTheme
 
 @Composable
@@ -41,8 +40,8 @@ fun InputField(
     Row(
         modifier = modifier
             .background(AsideTheme.colors.blackHole)
+            .windowInsetsPadding(WindowInsets.ime.union(WindowInsets.navigationBars))
             .padding(horizontal = 16.dp)
-            .padding(bottom = WindowInsets.ime.asPaddingValues().calculateBottomPadding())
             .heightIn(min = 48.dp),
         verticalAlignment = Alignment.Bottom
     ) {

--- a/app/src/main/java/com/alisher/aside/ui/debug/ChatScreenPreview.kt
+++ b/app/src/main/java/com/alisher/aside/ui/debug/ChatScreenPreview.kt
@@ -1,13 +1,7 @@
 package com.alisher.aside.ui.debug
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -19,21 +13,27 @@ import com.alisher.aside.ui.theme.AsideTheme
 fun ChatScreenPreview() {
     AsideTheme {
         val online = remember { mutableStateOf(true) }
+        val draft  = remember { mutableStateOf("") }
 
         Column(Modifier.fillMaxSize()) {
             ChatScreen(
-                peerState = if (online.value) PeerState.Connected else PeerState.Offline,
-                onExit = { }
+                peerState     = if (online.value) PeerState.Connected else PeerState.Offline,
+                draft         = draft.value,
+                onDraftChange = { draft.value = it },
+                onExit        = {}
             )
 
-            Row(Modifier.padding(16.dp), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+            Row(
+                Modifier.padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
                 SendQueueButton(
-                    type = ButtonType.Send,
+                    type  = ButtonType.Send,
                     state = ButtonState.Default,
                     onClick = { online.value = true }
                 )
                 SendQueueButton(
-                    type = ButtonType.Queue,
+                    type  = ButtonType.Queue,
                     state = ButtonState.Default,
                     onClick = { online.value = false }
                 )

--- a/app/src/main/java/com/alisher/aside/ui/layout/LayoutWrapper.kt
+++ b/app/src/main/java/com/alisher/aside/ui/layout/LayoutWrapper.kt
@@ -6,8 +6,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.layout.systemBars
 
-/** Simple wrapper applying safe drawing insets. */
+
+/** Simple wrapper applying safe system bar insets. */
 @Composable
 fun LayoutWrapper(
     modifier: Modifier = Modifier,
@@ -16,7 +18,7 @@ fun LayoutWrapper(
     Box(
         modifier
             .fillMaxSize()
-            .windowInsetsPadding(WindowInsets.safeDrawing)
+            .windowInsetsPadding(WindowInsets.systemBars)
     ) {
         content()
     }

--- a/app/src/main/java/com/alisher/aside/ui/layout/LayoutWrapper.kt
+++ b/app/src/main/java/com/alisher/aside/ui/layout/LayoutWrapper.kt
@@ -1,0 +1,23 @@
+package com.alisher.aside.ui.layout
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/** Simple wrapper applying safe drawing insets. */
+@Composable
+fun LayoutWrapper(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Box(
+        modifier
+            .fillMaxSize()
+            .windowInsetsPadding(WindowInsets.safeDrawing)
+    ) {
+        content()
+    }
+}


### PR DESCRIPTION
## Summary
- keep ChatScreen on-screen when IME appears
- update InputField to pad against both nav bars and keyboard
- provide safe drawing wrapper

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_b_68445af4af1c8331956f84c5a5b5baa5