### PR TITLE
Fix keyboard insets

### DIFF
--- a/app/src/main/java/com/alisher/aside/ui/components/ChatScreen.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/ChatScreen.kt
@@ -2,9 +2,9 @@ package com.alisher.aside.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import com.alisher.aside.ui.theme.AsideTheme
 
 @Composable
@@ -15,28 +15,33 @@ fun ChatScreen(
 ) {
     var input by remember { mutableStateOf("") }
 
-    Column(
+    val buttonType = if (peerState == PeerState.Connected) {
+        ButtonType.Send
+    } else {
+        ButtonType.Queue
+    }
+
+    Scaffold(
         modifier = modifier
             .fillMaxSize()
-            .background(AsideTheme.colors.blackHole)
-    ) {
-        SessionTopBar(peerState = peerState, onExit = onExit)
-
-        Box(modifier = Modifier.weight(1f)) {
+            .background(AsideTheme.colors.blackHole),
+        topBar = { SessionTopBar(peerState = peerState, onExit = onExit) },
+        bottomBar = {
+            InputField(
+                text = input,
+                onValueChange = { input = it },
+                buttonType = buttonType,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .windowInsetsPadding(WindowInsets.navigationBars)
+                    .windowInsetsPadding(WindowInsets.ime)
+            )
+        }
+    ) { padding ->
+        Box(Modifier
+            .padding(padding)
+            .fillMaxSize()) {
             // TODO: Replace with LazyColumn for chat messages
         }
-
-        val buttonType = if (peerState == PeerState.Connected) {
-            ButtonType.Send
-        } else {
-            ButtonType.Queue
-        }
-
-        InputField(
-            text = input,
-            onValueChange = { input = it },
-            buttonType = buttonType,
-            modifier = Modifier.fillMaxWidth()
-        )
     }
 }

--- a/app/src/main/java/com/alisher/aside/ui/components/InputField.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/InputField.kt
@@ -2,7 +2,6 @@ package com.alisher.aside.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.layout.navigationBarsWithImePadding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -40,8 +39,7 @@ fun InputField(
         modifier = modifier
             .background(AsideTheme.colors.blackHole)
             .padding(horizontal = 16.dp)
-            .heightIn(min = 48.dp)
-            .navigationBarsWithImePadding(),
+            .heightIn(min = 48.dp),
         verticalAlignment = Alignment.Bottom
     ) {
         var internalValue by rememberSaveable(stateSaver = TextFieldValue.Saver) {


### PR DESCRIPTION
## Summary
- convert ChatScreen to Scaffold with bottom bar insets
- drop old navigationBarsWithImePadding from InputField

## Testing
- `sh ./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6844721c7d148331b810b6c4a17abbe2