### PR TITLE
Ensure input field stays above keyboard

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,7 +17,7 @@
             android:exported="true"
             android:label="@string/app_name"
             android:theme="@style/Theme.Aside"
-            android:windowSoftInputMode="adjustNothing">
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/com/alisher/aside/MainActivity.kt
+++ b/app/src/main/java/com/alisher/aside/MainActivity.kt
@@ -3,11 +3,13 @@ package com.alisher.aside
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.core.view.WindowCompat
 import com.alisher.aside.ui.theme.*
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             AsideTheme {
                 AsideApp()


### PR DESCRIPTION
## Summary
- keep window decorations insets to make Compose aware of the keyboard
- resize activity when keyboard appears

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68449253d93c833196b8c2f2627270dd