### PR TITLE
Ensure SessionTopBar respects system status bar

### DIFF
--- a/app/src/main/java/com/alisher/aside/ui/components/SessionTopBar.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/SessionTopBar.kt
@@ -2,6 +2,7 @@ package com.alisher.aside.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -22,8 +23,9 @@ fun SessionTopBar(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .height(48.dp)
-            .background(Color.Black),
+            .background(Color.Black)
+            .statusBarsPadding()
+            .height(48.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         // left padding 20 dp as per spec lives inside the status component


### PR DESCRIPTION
## Summary
- import statusBarsPadding
- adjust SessionTopBar Row modifier so the content is pushed below the system status bar

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_684494dbf92c8331ab2ef8357d0708df