### PR TITLE
Add visible cursor to InputField

### DIFF
--- a/app/src/main/java/com/alisher/aside/ui/components/InputField.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/InputField.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.SolidColor
 import com.alisher.aside.ui.theme.AsideTheme
 
 /* inset helpers */
@@ -85,7 +86,8 @@ fun InputField(
             ),
             keyboardOptions  = KeyboardOptions.Default.copy(imeAction = ImeAction.Default),
             keyboardActions  = KeyboardActions(onDone = { focusMgr.clearFocus() }),
-            singleLine       = false
+            singleLine       = false,
+            cursorBrush      = SolidColor(AsideTheme.colors.whitePure)
         )
 
         Spacer(Modifier.width(16.dp))


### PR DESCRIPTION
## Summary
- ensure comment input shows a blinking cursor by explicitly setting the cursor brush color

## Testing
- `sh ./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_684496391f1c8331ab94966f256b12c7