### PR TITLE
Add cursor brush to input field

### DIFF
--- a/app/src/main/java/com/alisher/aside/ui/components/InputField.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/InputField.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.graphics.SolidColor
 import com.alisher.aside.ui.theme.AsideTheme
 
 /* inset helpers */
@@ -84,6 +85,7 @@ fun InputField(
                 textStyle = AsideTheme.typography.bodyMedium.copy(
                     color = AsideTheme.colors.whitePure
                 ),
+                cursorBrush    = SolidColor(AsideTheme.colors.whitePure),
                 keyboardOptions  = KeyboardOptions.Default.copy(imeAction = ImeAction.Default),
                 keyboardActions  = KeyboardActions(onDone = { focusMgr.clearFocus() }),
                 singleLine       = false


### PR DESCRIPTION
## Summary
- show a blinking cursor by setting `cursorBrush` in `InputField`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_684498c606e4833181aa8cf0f3d184a6