### PR TITLE
Adjust InputField bottom padding

### DIFF
--- a/app/src/main/java/com/alisher/aside/ui/components/InputField.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/InputField.kt
@@ -58,8 +58,8 @@ fun InputField(
         Row(
             modifier = Modifier
                 .padding(top = 16.dp)
-                // tiny safety pad for OEM quirks
-                .padding(bottom = 8.dp)
+                // safety pad for OEM quirks
+                .padding(bottom = 16.dp)
                 .padding(horizontal = 16.dp)
                 .heightIn(min = 48.dp),
             verticalAlignment = Alignment.Bottom


### PR DESCRIPTION
## Summary
- increase bottom padding on InputField component to 16dp

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68449a09b1cc8331a1d17ce5838ddd86