### PR TITLE
Move toasts to top of screen

### DIFF
--- a/app/src/main/java/com/alisher/aside/App.kt
+++ b/app/src/main/java/com/alisher/aside/App.kt
@@ -3,11 +3,11 @@ package com.alisher.aside
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context.CLIPBOARD_SERVICE
-import android.widget.Toast
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalContext
 import com.alisher.aside.ui.components.*
+import com.alisher.aside.util.showTopToast
 
 private const val DUMMY_INVITE =
     "Let\u2019s step aside: 03b1a3cf0ae3f8b6cc1937124e36f51b9e8e3f024f18ec1479d07ec0f27c50a3d9"
@@ -26,13 +26,10 @@ fun AsideApp() {
             onCreate = {
                 (context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager)
                     .setPrimaryClip(ClipData.newPlainText("invite", DUMMY_INVITE))
-                Toast
-                    .makeText(
-                        context,
-                        "Invite copied to clipboard. Send it to your peer.",
-                        Toast.LENGTH_SHORT
-                    )
-                    .show()
+                showTopToast(
+                    context,
+                    "Invite copied to clipboard. Send it to your peer."
+                )
                 screen = AppScreen.Chat
             }
         )

--- a/app/src/main/java/com/alisher/aside/AsideScreen.kt
+++ b/app/src/main/java/com/alisher/aside/AsideScreen.kt
@@ -2,7 +2,7 @@ package com.alisher.aside
 
 import android.content.ClipboardManager
 import android.content.Context.CLIPBOARD_SERVICE
-import android.widget.Toast
+import com.alisher.aside.util.showTopToast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -55,7 +55,7 @@ fun AsideScreen(
                     } else {
                         "Clipboard is empty"
                     }
-                    Toast.makeText(context, "Pasted: $pasted", Toast.LENGTH_SHORT).show()
+                    showTopToast(context, "Pasted: $pasted")
                 },
             contentAlignment = Alignment.Center // ✅ center it properly
         ) {

--- a/app/src/main/java/com/alisher/aside/ui/debug/SessionTestScreen.kt
+++ b/app/src/main/java/com/alisher/aside/ui/debug/SessionTestScreen.kt
@@ -3,7 +3,7 @@ package com.alisher.aside.ui.debug
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
-import android.widget.Toast
+import com.alisher.aside.util.showTopToast
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Button
 import androidx.compose.material3.Divider
@@ -47,13 +47,13 @@ fun SessionTestScreen(viewModel: SessionViewModel = viewModel()) {
                 val fakeInvite = "Let’s step aside: ${System.currentTimeMillis().toString(16)}"
                 val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                 clipboard.setPrimaryClip(ClipData.newPlainText("invite", fakeInvite))
-                Toast.makeText(context, "Invite copied to clipboard. Send it to your peer.", Toast.LENGTH_SHORT).show()
+                showTopToast(context, "Invite copied to clipboard. Send it to your peer.")
             }) {
                 Text("Start Session")
             }
             Button(modifier = Modifier.fillMaxWidth(), onClick = {
                 viewModel.exitSession()
-                Toast.makeText(context, "Nothing here", Toast.LENGTH_SHORT).show()
+                showTopToast(context, "Nothing here")
             }) {
                 Text("Exit Session")
             }

--- a/app/src/main/java/com/alisher/aside/util/ToastUtils.kt
+++ b/app/src/main/java/com/alisher/aside/util/ToastUtils.kt
@@ -1,0 +1,11 @@
+package com.alisher.aside.util
+
+import android.content.Context
+import android.view.Gravity
+import android.widget.Toast
+
+fun showTopToast(context: Context, message: String, duration: Int = Toast.LENGTH_SHORT) {
+    val toast = Toast.makeText(context, message, duration)
+    toast.setGravity(Gravity.TOP or Gravity.CENTER_HORIZONTAL, 0, 0)
+    toast.show()
+}


### PR DESCRIPTION
## Summary
- centralize toast layout in `showTopToast`
- import and use `showTopToast` in all screens

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68449b7c2da48331b2d4711290542afe