### PR TITLE
Ensure all toasts appear at the top

### DIFF
--- a/app/src/main/java/com/alisher/aside/App.kt
+++ b/app/src/main/java/com/alisher/aside/App.kt
@@ -5,8 +5,12 @@ import android.content.ClipboardManager
 import android.content.Context.CLIPBOARD_SERVICE
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import com.alisher.aside.ui.components.*
+import com.alisher.aside.ui.components.TopToastHost
 import com.alisher.aside.util.showTopToast
 
 private const val DUMMY_INVITE =
@@ -21,24 +25,27 @@ fun AsideApp() {
     var draft        by rememberSaveable { mutableStateOf("") }
     val peerState    = remember { PeerState.Offline }   // stub until real connect
 
-    when (screen) {
-        AppScreen.Home -> AsideScreen(
-            onCreate = {
-                (context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager)
-                    .setPrimaryClip(ClipData.newPlainText("invite", DUMMY_INVITE))
-                showTopToast(
-                    context,
-                    "Invite copied to clipboard. Send it to your peer."
-                )
-                screen = AppScreen.Chat
-            }
-        )
+    Box(Modifier.fillMaxSize()) {
+        when (screen) {
+            AppScreen.Home -> AsideScreen(
+                onCreate = {
+                    (context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager)
+                        .setPrimaryClip(ClipData.newPlainText("invite", DUMMY_INVITE))
+                    showTopToast(
+                        context,
+                        "Invite copied to clipboard. Send it to your peer."
+                    )
+                    screen = AppScreen.Chat
+                }
+            )
 
-        AppScreen.Chat -> ChatScreen(
-            peerState     = peerState,
-            draft         = draft,
-            onDraftChange = { draft = it },
-            onExit        = { screen = AppScreen.Home }
-        )
+            AppScreen.Chat -> ChatScreen(
+                peerState     = peerState,
+                draft         = draft,
+                onDraftChange = { draft = it },
+                onExit        = { screen = AppScreen.Home }
+            )
+        }
+        TopToastHost(Modifier.fillMaxSize())
     }
 }

--- a/app/src/main/java/com/alisher/aside/ui/components/TopToast.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/TopToast.kt
@@ -1,0 +1,66 @@
+package com.alisher.aside.ui.components
+
+import android.widget.Toast
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.ui.unit.dp
+import com.alisher.aside.ui.theme.AsideTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+object TopToastManager {
+    private val scope = CoroutineScope(Dispatchers.Main)
+    private const val SHORT_DURATION = 2000L
+    private const val LONG_DURATION = 3500L
+
+    var message by mutableStateOf<String?>(null)
+        private set
+
+    fun show(message: String, duration: Int = Toast.LENGTH_SHORT) {
+        val delayMillis = if (duration == Toast.LENGTH_LONG) LONG_DURATION else SHORT_DURATION
+        scope.launch {
+            this@TopToastManager.message = message
+            delay(delayMillis)
+            this@TopToastManager.message = null
+        }
+    }
+}
+
+@Composable
+fun TopToastHost(modifier: Modifier = Modifier) {
+    val currentMessage = TopToastManager.message
+    Box(modifier = modifier.fillMaxSize()) {
+        AnimatedVisibility(
+            visible = currentMessage != null,
+            enter = fadeIn(),
+            exit = fadeOut(),
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .padding(top = 24.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .background(AsideTheme.colors.grayGraphene, RoundedCornerShape(4.dp))
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+            ) {
+                Text(
+                    text = currentMessage ?: "",
+                    color = AsideTheme.colors.whitePure,
+                    style = AsideTheme.typography.bodyLarge
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/alisher/aside/util/ToastUtils.kt
+++ b/app/src/main/java/com/alisher/aside/util/ToastUtils.kt
@@ -1,11 +1,9 @@
 package com.alisher.aside.util
 
 import android.content.Context
-import android.view.Gravity
 import android.widget.Toast
+import com.alisher.aside.ui.components.TopToastManager
 
 fun showTopToast(context: Context, message: String, duration: Int = Toast.LENGTH_SHORT) {
-    val toast = Toast.makeText(context, message, duration)
-    toast.setGravity(Gravity.TOP or Gravity.CENTER_HORIZONTAL, 0, 0)
-    toast.show()
+    TopToastManager.show(message, duration)
 }


### PR DESCRIPTION
## Summary
- implement `TopToastManager` and `TopToastHost` composable to display custom toast messages
- route `showTopToast` through the new manager
- overlay `TopToastHost` in `AsideApp`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68449d4d08048331a9fdbbdd9d199342