### PR TITLE
Align top bar components

### DIFF
--- a/app/src/main/java/com/alisher/aside/ui/components/ExitButton.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/ExitButton.kt
@@ -12,14 +12,16 @@ import androidx.compose.material3.Text
 import com.alisher.aside.ui.theme.AsideTheme
 
 @Composable
-fun ExitButton(onClick: () -> Unit) {
+fun ExitButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     Box(
         contentAlignment = Alignment.CenterEnd,
-        modifier = Modifier
+        modifier = modifier
             .sizeIn(minWidth = 48.dp, minHeight = 48.dp)
             .clickable { onClick() }   // ≥48 dp touch area
-    )
-            {
+    ) {
         Text(
             text = "Exit",
             style = AsideTheme.typography.bodyLarge,

--- a/app/src/main/java/com/alisher/aside/ui/components/SessionTopBar.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/SessionTopBar.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.alignByBaseline
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.alisher.aside.ui.theme.AsideTheme
@@ -29,13 +30,13 @@ fun SessionTopBar(
         verticalAlignment = Alignment.CenterVertically
     ) {
         // left padding 20 dp as per spec lives inside the status component
-        ConnectionStatus(peerState)
+        ConnectionStatus(peerState, modifier = Modifier.alignByBaseline())
 
         Spacer(Modifier.weight(1f))
 
         // 20‑dp trailing padding to mirror the leading padding
         Row(Modifier.padding(end = 20.dp)) {
-            ExitButton(onExit)
+            ExitButton(onExit, modifier = Modifier.alignByBaseline())
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow customizing `ExitButton` layout
- vertically align `ConnectionStatus` and `ExitButton` in the SessionTopBar

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6844a13cb5408331bd93e5c628f0682c