### PR TITLE
Set status bar to black

### DIFF
--- a/app/src/main/java/com/alisher/aside/MainActivity.kt
+++ b/app/src/main/java/com/alisher/aside/MainActivity.kt
@@ -4,6 +4,9 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.core.view.WindowCompat
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.alisher.aside.ui.theme.*
 
 class MainActivity : ComponentActivity() {
@@ -11,6 +14,13 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
+            val systemUiController = rememberSystemUiController()
+            SideEffect {
+                systemUiController.setStatusBarColor(
+                    color = Color.Black,
+                    darkIcons = false
+                )
+            }
             AsideTheme {
                 AsideApp()
             }


### PR DESCRIPTION
## Summary
- control system status bar using `SystemUiController`
- ensure light icons on a solid black status bar for minimal UI

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6844a69ddeec8331b90af41253594eb7