### PR TITLE
Set OS status bar black

### DIFF
--- a/app/src/main/java/com/alisher/aside/MainActivity.kt
+++ b/app/src/main/java/com/alisher/aside/MainActivity.kt
@@ -1,15 +1,19 @@
 package com.alisher.aside
 
+import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import com.alisher.aside.ui.theme.*
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         WindowCompat.setDecorFitsSystemWindows(window, false)
+        window.statusBarColor = Color.BLACK
+        WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars = false
         setContent {
             AsideTheme {
                 AsideApp()


### PR DESCRIPTION
## Summary
- colorize the OS status bar

## Testing
- `./gradlew test --quiet` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6844aaf6711c83318318ced4099fdc79