### PR TITLE
Keep keyboard visible after sending message

### DIFF
--- a/app/src/main/java/com/alisher/aside/ui/components/InputField.kt
+++ b/app/src/main/java/com/alisher/aside/ui/components/InputField.kt
@@ -100,7 +100,6 @@ fun InputField(
                 type  = buttonType,
                 state = btnState,
                 onClick = {
-                    keyboard?.hide()
                     onValueChange("")
                     internal = TextFieldValue("")
                 },


### PR DESCRIPTION
## Summary
- prevent InputField button from hiding the keyboard

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6844ae303c7c83319b121c7fa080cc9e