### PR TITLE
Remove extra clipboard toast

### DIFF
--- a/app/src/main/java/com/alisher/aside/App.kt
+++ b/app/src/main/java/com/alisher/aside/App.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalContext
 import com.alisher.aside.ui.components.*
-import com.alisher.aside.util.showTopToast
 
 private const val DUMMY_INVITE =
     "Let\u2019s step aside: 03b1a3cf0ae3f8b6cc1937124e36f51b9e8e3f024f18ec1479d07ec0f27c50a3d9"
@@ -26,10 +25,6 @@ fun AsideApp() {
             onCreate = {
                 (context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager)
                     .setPrimaryClip(ClipData.newPlainText("invite", DUMMY_INVITE))
-                showTopToast(
-                    context,
-                    "Invite copied to clipboard. Send it to your peer."
-                )
                 screen = AppScreen.Chat
             }
         )

--- a/app/src/main/java/com/alisher/aside/ui/debug/SessionTestScreen.kt
+++ b/app/src/main/java/com/alisher/aside/ui/debug/SessionTestScreen.kt
@@ -47,7 +47,6 @@ fun SessionTestScreen(viewModel: SessionViewModel = viewModel()) {
                 val fakeInvite = "Let’s step aside: ${System.currentTimeMillis().toString(16)}"
                 val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
                 clipboard.setPrimaryClip(ClipData.newPlainText("invite", fakeInvite))
-                showTopToast(context, "Invite copied to clipboard. Send it to your peer.")
             }) {
                 Text("Start Session")
             }


### PR DESCRIPTION
## Summary
- disable custom toast when copying invite to clipboard

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6844b0cd2e888331b8f00643133d1d95