### PR TITLE
Move toast to screen top

### DIFF
--- a/app/src/main/java/com/alisher/aside/util/ToastUtils.kt
+++ b/app/src/main/java/com/alisher/aside/util/ToastUtils.kt
@@ -6,6 +6,7 @@ import android.widget.Toast
 
 fun showTopToast(context: Context, message: String, duration: Int = Toast.LENGTH_SHORT) {
     val toast = Toast.makeText(context, message, duration)
-    toast.setGravity(Gravity.TOP or Gravity.CENTER_HORIZONTAL, 0, 0)
+    val yOffset = (32 * context.resources.displayMetrics.density).toInt()
+    toast.setGravity(Gravity.TOP or Gravity.CENTER_HORIZONTAL, 0, yOffset)
     toast.show()
 }


### PR DESCRIPTION
## Summary
- offset native toast from the top so it displays above system bars

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6844b20eea2c8331b878a15cc46d6388